### PR TITLE
GetPath + multiple root fix

### DIFF
--- a/src/components/VrxTree/VrxTree.stories.ts
+++ b/src/components/VrxTree/VrxTree.stories.ts
@@ -149,6 +149,9 @@ const Template : TreeStories = {
             findNode(){
                 alert(JSON.stringify(this.$refs.myRef.getNodeByText("Sub Sub Child 0")));
             },
+            findPath(){
+                alert(JSON.stringify(this.$refs.myRef.getNodePath(this.$refs.myRef.getNodeByText("Sub Sub Child 0").id)));
+            },
         },
         template: `
           <div style="height: auto; width: auto">
@@ -156,6 +159,7 @@ const Template : TreeStories = {
                 <div style="padding-top: 30px; display: flex; flex-direction: row; gap: 5px">
                     <VrxButton color="default" size="sm" @click="logSelected" >Log selected nodes</VrxButton>
                     <VrxButton color="default" size="sm" @click="findNode" >Log found node (Sub Sub Child 0)</VrxButton>
+                    <VrxButton color="default" size="sm" @click="findPath" >Log find path (Sub Sub Child 0)</VrxButton>
                 </div>
           </div>
          

--- a/src/components/VrxTree/VrxTree.test.ts
+++ b/src/components/VrxTree/VrxTree.test.ts
@@ -112,6 +112,15 @@ describe('VrxTree', () => {
         expect(wrapper.vm.flattenTree(data[0]).length).toBe(6);
     });
 
+    it("should find the path of a node", () => {
+        wrapper = mount(VrxTree as any, {props: {data: data2}});
+        const nodeId: string = wrapper.vm.getNodeByText("Children 0").id;
+        const path = wrapper.vm.getNodePath(nodeId);
+
+        expect(path).toEqual(['0', 'Children 0']);
+
+    })
+
     it("renders a node as component", () => {
         wrapper = mount(VrxTree as any, {props: {data: dataWithComponent}});
         wrapper.findAll('button').forEach((node, index) => {

--- a/src/components/VrxTree/VrxTree.vue
+++ b/src/components/VrxTree/VrxTree.vue
@@ -137,7 +137,7 @@
   }
 
   /**
-   * Return the parent of the passed node, if have no parent return nullù
+   * Return the parent of the passed node, if have no parent return null
    * @param toFind VrxTreeNode
    */
   const getParentNode = (toFind: VrxTreeNode) => {
@@ -159,6 +159,20 @@
   }
 
   /**
+   * Return the complete path of the node
+   * @param nodeId
+   */
+  const getNodePath = (nodeId: string): String[] => {
+    const node: VrxTreeNode | null = getNodeById(nodeId);
+    const _recursiveFind = (toFind: VrxTreeNode | null): String[] => {
+      if(!toFind) return [];
+      else return _recursiveFind(getParentNode(toFind)).concat([toFind.text]);
+    }
+
+    return (_recursiveFind(node));
+  }
+
+  /**
    * Returns the selected nodes
    */
   const getSelectedNodes = () => {
@@ -176,7 +190,10 @@
       }
     }
 
-    traverse(props.data[0]);
+    props.data.forEach((dt) => {
+      traverse(dt);
+    })
+
     const flatMapResult = result.flatMap(node => flattenTree(node));
     return props.returnsUserData ? flatMapResult.map(node => node.userData ?? node) : flatMapResult;
   }
@@ -205,7 +222,7 @@
   const emit = defineEmits(['cellClicked']);
   buildTreeWithIds(props.data);
 
-  defineExpose({ getSelectedNodes, getNodeByText, removeNodeById, addNode, removeNode, flattenTree, getNodeById, getParentNode });
+  defineExpose({ getNodePath, getSelectedNodes, getNodeByText, removeNodeById, addNode, removeNode, flattenTree, getNodeById, getParentNode });
 
 </script>
 


### PR DESCRIPTION
- Added function `GetNodePath(id: string)` which would return an array of the node path.
- Fixed the multiple root issue. Now if I have 2 parents on the top hierarchy level, both will be scanned for selectedNodes